### PR TITLE
[김선규] 260306 B1937

### DIFF
--- a/kimsg125/week01/B1937/README.md
+++ b/kimsg125/week01/B1937/README.md
@@ -1,0 +1,49 @@
+# 🐼 BOJ 1937 - 욕심쟁이 판다
+
+- 🔗 문제 링크: https://www.acmicpc.net/problem/1937  
+- 🏷️ 분류: DFS + DP(메모이제이션) / 그래프 DP
+
+---
+
+## 💡 접근 아이디어 / 시행착오
+- 모든 시작점에서 bfs로 탐색하고 dp에 저장해서 탐색 시간을 줄이자
+- bfs로 하니까 메모리 초과가 나온다
+- 그럼 dfs로 하면서 dp를 업데이트하자
+
+---
+
+## 🛠️ 구현 포인트
+```
+for (int i = 0; i < N; i++) {
+	for (int j = 0; j < N; j++) {
+		ans = Math.max(ans, dfs(i, j));
+	}
+}
+```
+모든 시작점에서 dfs
+
+```
+if (dp[x][y] != 0)
+	return dp[x][y];
+```
+탐색이 완료된 곳은 리턴
+
+```
+dp[x][y] = 1;
+for (int i = 0; i < 4; i++) {
+	int nx = x + dx[i], ny = y + dy[i];
+	if (nx < 0 || nx > N - 1 || ny < 0 || ny > N - 1 || Map[nx][ny] <= Map[x][y])
+		continue;
+
+	dp[x][y] = Math.max(dp[x][y], dfs(nx, ny) + 1);
+}
+```
+최소 1, (주변 탐색한 값+1)이 더 크면 업데이트
+
+---
+
+## 📝 배운 점
+- 너무 bfs를 편애한다
+- dfs도 좋아해보자
+
+---

--- a/kimsg125/week01/B1937/b1937.java
+++ b/kimsg125/week01/B1937/b1937.java
@@ -1,0 +1,70 @@
+package com.ssafy.algo.fairy.m3.week01.B1937;
+
+import java.util.*;
+import java.io.*;
+
+public class b1937 {
+
+	static class Point {
+		int x, y, d;
+
+		public Point(int x, int y, int d) {
+			this.x = x;
+			this.y = y;
+			this.d = d;
+		}
+	}
+
+	static int N, ans;
+
+	static int[][] Map, dp;
+
+	static Queue<Point> q = new LinkedList<>();
+
+	static int[] dx = { -1, 1, 0, 0 };
+	static int[] dy = { 0, 0, -1, 1 };
+
+	public static void main(String[] args) throws Exception {
+
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+
+		N = Integer.parseInt(br.readLine());
+
+		Map = new int[N][N];
+
+		for (int i = 0; i < N; i++) {
+			StringTokenizer st = new StringTokenizer(br.readLine());
+			for (int j = 0; j < N; j++)
+				Map[i][j] = Integer.parseInt(st.nextToken());
+		}
+
+		ans = 0;
+		dp = new int[N][N];
+
+		for (int i = 0; i < N; i++) {
+			for (int j = 0; j < N; j++) {
+				ans = Math.max(ans, dfs(i, j));
+			}
+		}
+
+		System.out.println(ans);
+
+	}
+
+	static int dfs(int x, int y) {
+		if (dp[x][y] != 0)
+			return dp[x][y];
+
+		dp[x][y] = 1;
+		for (int i = 0; i < 4; i++) {
+			int nx = x + dx[i], ny = y + dy[i];
+			if (nx < 0 || nx > N - 1 || ny < 0 || ny > N - 1 || Map[nx][ny] <= Map[x][y])
+				continue;
+
+			dp[x][y] = Math.max(dp[x][y], dfs(nx, ny) + 1);
+		}
+
+		return dp[x][y];
+	}
+
+}


### PR DESCRIPTION
# 🐼 BOJ 1937 - 욕심쟁이 판다 (#32)

- 🔗 문제 링크: https://www.acmicpc.net/problem/1937  
- 🏷️ 분류: DFS + DP(메모이제이션) / 그래프 DP

---

## 💡 접근 아이디어 / 시행착오
- 모든 시작점에서 bfs로 탐색하고 dp에 저장해서 탐색 시간을 줄이자
- bfs로 하니까 메모리 초과가 나온다
- 그럼 dfs로 하면서 dp를 업데이트하자

---

## 🛠️ 구현 포인트
```
for (int i = 0; i < N; i++) {
	for (int j = 0; j < N; j++) {
		ans = Math.max(ans, dfs(i, j));
	}
}
```
모든 시작점에서 dfs

```
if (dp[x][y] != 0)
	return dp[x][y];
```
탐색이 완료된 곳은 리턴

```
dp[x][y] = 1;
for (int i = 0; i < 4; i++) {
	int nx = x + dx[i], ny = y + dy[i];
	if (nx < 0 || nx > N - 1 || ny < 0 || ny > N - 1 || Map[nx][ny] <= Map[x][y])
		continue;

	dp[x][y] = Math.max(dp[x][y], dfs(nx, ny) + 1);
}
```
최소 1, (주변 탐색한 값+1)이 더 크면 업데이트

---

## 📝 배운 점
- 너무 bfs를 편애한다
- dfs도 좋아해보자

---